### PR TITLE
feat: auto-create user profiles via Better Auth middleware

### DIFF
--- a/src/app/(dashboard)/members/[memberId]/page.tsx
+++ b/src/app/(dashboard)/members/[memberId]/page.tsx
@@ -26,7 +26,7 @@ const MemberIdPage = async ({ params }: MemberIdPageProps) => {
 
   const queryClient = getQueryClient();
   void queryClient.prefetchQuery(
-    trpc.profile.getOneOrCreate.queryOptions({ userId: memberId }),
+    trpc.profile.getOne.queryOptions({ userId: memberId }),
   );
 
   return (

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -22,7 +22,7 @@ const ProfilePage = async () => {
 
   const queryClient = getQueryClient();
   void queryClient.prefetchQuery(
-    trpc.profile.getOneOrCreate.queryOptions({ userId: session.user.id }),
+    trpc.profile.getOne.queryOptions({ userId: session.user.id }),
   );
 
   return (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { admin } from "better-auth/plugins";
+import { admin, createAuthMiddleware } from "better-auth/plugins";
 
 import { db } from "@/db";
 import * as dbSchema from "@/db/schema";
@@ -20,6 +20,25 @@ export const auth = betterAuth({
       clientId: process.env.GOOGLE_CLIENT_ID as string,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
     },
+  },
+
+  hooks: {
+    after: createAuthMiddleware(async (ctx) => {
+      const user = ctx.context.session?.user;
+
+      if (!user) return;
+
+      const now = new Date();
+      const userCreatedAt = new Date(user.createdAt || "");
+
+      // Check if user was created within the last 5 seconds
+      const isNewUser = now.getTime() - userCreatedAt.getTime() < 5000;
+
+      if (isNewUser) {
+        await db.insert(dbSchema.profile).values({ userId: user.id });
+        console.log("Profile created for user:", { name: user.name });
+      }
+    }),
   },
 
   plugins: [admin({ defaultRole: "member" })],

--- a/src/modules/auth/ui/views/sign-in-view.tsx
+++ b/src/modules/auth/ui/views/sign-in-view.tsx
@@ -43,6 +43,7 @@ export const SignInView = () => {
     },
   });
 
+
   const onGoogleSubmit = () => {
     setIsPending(true);
     setError(null);
@@ -182,13 +183,13 @@ export const SignInView = () => {
             </form>
           </Form>
 
-          <div className="bg-gradient-to-br from-[#000000] via-[#ED1C24] via-60% to-[#FFF200] hidden relative md:block">
+          <div className="relative hidden bg-gradient-to-br from-[#000000] via-[#ED1C24] via-60% to-[#FFF200] md:block">
             <Image
               src="/gitgud-logo.png"
               alt="Image"
               fill
               priority
-              className="object-contain backdrop-blur-5xl"
+              className="backdrop-blur-5xl object-contain"
             />
           </div>
         </CardContent>

--- a/src/modules/auth/ui/views/sign-up-view.tsx
+++ b/src/modules/auth/ui/views/sign-up-view.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+
 import { z } from "zod";
 
 import { OctagonAlertIcon } from "lucide-react";
@@ -43,7 +44,6 @@ const formSchema = z
 export const SignUpView = () => {
   const [error, setError] = useState<string | null>(null);
   const [isPending, setIsPending] = useState(false);
-
   const router = useRouter();
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -94,10 +94,11 @@ export const SignUpView = () => {
         callbackURL: "/",
       },
       {
-        onSuccess: async () => {
-          router.push("/");
+        onSuccess: async ({ data }) => {
           setIsPending(false);
           setError(null);
+
+          router.push("/");
         },
         onError: ({ error }) => {
           setIsPending(false);
@@ -121,7 +122,6 @@ export const SignUpView = () => {
                   </p>
                 </div>
 
-                {/* Email Input */}
                 <FormField
                   control={form.control}
                   name="email"
@@ -143,7 +143,6 @@ export const SignUpView = () => {
                   )}
                 />
 
-                {/* Name Input */}
                 <div className="grid gap-3">
                   <FormField
                     control={form.control}
@@ -198,7 +197,6 @@ export const SignUpView = () => {
                   )}
                 />
 
-                {/* ConfirmPassword Input */}
                 <FormField
                   control={form.control}
                   name="confirmPassword"

--- a/src/modules/dashboard/ui/components/dashboard-sidebar.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-sidebar.tsx
@@ -47,7 +47,7 @@ export const DashboardSidebar = () => {
   const pathname = usePathname();
 
   const { data: session } = authClient.useSession();
-  const currentUserIsAdmin = session?.user?.role === "admin";
+  const currentUserIsAdmin = session?.user.role === "admin";
 
   return (
     <Sidebar className="border-red-800/30 shadow-2xl">

--- a/src/modules/dashboard/ui/components/dashboard-user-button.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-user-button.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 
 import { authClient } from "@/lib/auth-client";
 
-import { ChevronDownIcon, CreditCardIcon, LogOutIcon } from "lucide-react";
+import { ChevronDownIcon, LogOutIcon } from "lucide-react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 

--- a/src/modules/members/ui/views/member-id-view.tsx
+++ b/src/modules/members/ui/views/member-id-view.tsx
@@ -15,7 +15,7 @@ export const MemberIdView = ({ userId }: MemberIdViewProps) => {
   const trpc = useTRPC();
 
   const { data } = useSuspenseQuery(
-    trpc.profile.getOneOrCreate.queryOptions({ userId }),
+    trpc.profile.getOne.queryOptions({ userId }),
   );
 
   return <ProfileCard profile={data} />;

--- a/src/modules/profile/server/procedures.ts
+++ b/src/modules/profile/server/procedures.ts
@@ -53,9 +53,10 @@ export const profileRouter = createTRPCRouter({
         });
       }
 
-      const createProfile = await db
+      const [createProfile] = await db
         .select()
         .from(profile)
+        .innerJoin(user, eq(user.id, profile.userId))
         .where(
           and(
             eq(profile.userId, input.userId),
@@ -96,7 +97,7 @@ export const profileRouter = createTRPCRouter({
       const name = `${firstName.trim()} ${lastName.trim()}`;
 
       // Update authclient user
-      const authResponse = await authClient.updateUser({ name });
+      // const authResponse = await authClient.updateUser({ name });
 
       // if (!authResponse.data?.status) {
       //   throw new TRPCError({

--- a/src/modules/profile/types.ts
+++ b/src/modules/profile/types.ts
@@ -2,4 +2,4 @@ import { inferRouterOutputs } from "@trpc/server";
 
 import { AppRouter } from "@/trpc/routers/_app";
 
-export type ProfileGetOne = inferRouterOutputs<AppRouter>["profile"]["getOneOrCreate"];
+export type ProfileGetOne = inferRouterOutputs<AppRouter>["profile"]["getOne"];

--- a/src/modules/profile/ui/components/edit-profile-dialog.tsx
+++ b/src/modules/profile/ui/components/edit-profile-dialog.tsx
@@ -4,10 +4,10 @@ import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 
-import { useTRPC } from "@/trpc/client";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-
 import { toast } from "sonner";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "@/trpc/client";
 
 import { profileInsertSchema } from "@/modules/profile/schema";
 import { ProfileGetOne } from "@/modules/profile/types";
@@ -69,7 +69,7 @@ export const EditProfileDialog = ({
     trpc.profile.edit.mutationOptions({
       onSuccess: async () => {
         await queryClient.invalidateQueries(
-          trpc.profile.getOneOrCreate.queryOptions({
+          trpc.profile.getOne.queryOptions({
             userId: initialValues.userId,
           }),
         );

--- a/src/modules/profile/ui/views/profile-view.tsx
+++ b/src/modules/profile/ui/views/profile-view.tsx
@@ -3,13 +3,7 @@
 import { useState } from "react";
 
 import { useTRPC } from "@/trpc/client";
-import {
-  useMutation,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-
-import { toast } from "sonner";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
 import { EditProfileDialog } from "@/modules/profile/ui/components/edit-profile-dialog";
 
@@ -27,7 +21,7 @@ export const ProfileView = ({ userId }: ProfileViewProps) => {
   const trpc = useTRPC();
 
   const { data: profile } = useSuspenseQuery(
-    trpc.profile.getOneOrCreate.queryOptions({ userId }),
+    trpc.profile.getOne.queryOptions({ userId }),
   );
 
   return (


### PR DESCRIPTION
Add automated profile creation for new users using Better Auth's after hook middleware. Profiles are created within 5 seconds of user registration for both email and social sign-ups.

chore: refactor profile service into separate functions

Split getOneOrCreate into distinct getOne and create functions for better separation of concerns and improved maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiles are now explicitly created for new users immediately after account creation.

* **Bug Fixes**
  * Improved profile fetching to only retrieve existing profiles, displaying an error if none is found.

* **Refactor**
  * Streamlined profile creation and retrieval logic for better consistency.
  * Adjusted admin role checks and optimized import statements for improved code clarity.

* **Style**
  * Minor reordering of CSS classes and removal of redundant blank lines for cleaner code appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->