### PR TITLE
feat: implement race statistics caching system

### DIFF
--- a/src/app/api/cronjobs/route.ts
+++ b/src/app/api/cronjobs/route.ts
@@ -12,13 +12,69 @@ export async function GET(request: NextRequest) {
   console.log("Cron job started at:", new Date().toISOString());
 
   const authCode = await helper.getOrRefreshAuthCode();
-  const cached = await helper.cacheSeries({ authCode });
 
-  if (!cached?.success) {
-    console.error("Cron job error:", cached?.error);
+  const seriesCached = await helper.cacheSeries({ authCode });
+
+  if (!seriesCached?.success) {
+    console.error("Cron job error:", seriesCached?.error);
+    return Response.json({ success: false }, { status: 500 });
+  }
+
+  const currentWeek = calculateCurrentWeek();
+  
+  const params = {
+    season_id: "5559", // 2025
+    event_type: "5",
+    race_week_num: "0",
+  };
+
+  const cachedWeeklyResults = await helper.cacheWeeklyResults({
+    authCode,
+    params,
+  });
+
+  if (!cachedWeeklyResults) {
+    console.error("Cron job error:", seriesCached?.error);
     return Response.json({ success: false }, { status: 500 });
   }
 
   console.log("Cron job completed successfully");
   return Response.json({ success: true });
 }
+
+const calculateCurrentWeek = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+
+  // iRacing seasons typically start on these dates (adjust based on actual schedule)
+  const seasonStarts = [
+    new Date(year, 2, 12), // Season 1: ~March 12 (Week 0)
+    new Date(year, 5, 11), // Season 2: ~June 11 (Week 0)
+    new Date(year, 8, 10), // Season 3: ~September 10 (Week 0)
+    new Date(year, 11, 10), // Season 4: ~December 10 (Week 0)
+  ];
+
+  // Find current season
+  let currentSeasonIndex = 0;
+  let seasonStartDate = seasonStarts[0];
+
+  for (let i = seasonStarts.length - 1; i >= 0; i--) {
+    if (now >= seasonStarts[i]) {
+      currentSeasonIndex = i;
+      seasonStartDate = seasonStarts[i];
+      break;
+    }
+  }
+
+  // Calculate weeks since season start
+  const msPerWeek = 7 * 24 * 60 * 60 * 1000;
+  const weeksSinceStart = Math.floor(
+    (now.getTime() - seasonStartDate.getTime()) / msPerWeek,
+  );
+
+  return {
+    currentWeek: Math.min(weeksSinceStart, 12), // Cap at 12 (0-12 = 13 weeks)
+    currentSeason: currentSeasonIndex + 1,
+    seasonStartDate,
+  };
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -199,13 +199,13 @@ export const seriesWeeklyStatsTable = mysqlTable("series_weekly_stats", {
     .primaryKey()
     .$default(() => nanoid()),
 
-  sessionId: int("session_id").notNull(),
+  sessionId: int("session_id").unique().notNull(),
   subSessionId: int("subsession_id").notNull(),
   seasonYear: int("season_year").notNull(),
   seasonQuarter: int("season_quarter").notNull(),
-  name: varchar("name", { length: 30 }).notNull(),
-  shortName: varchar("short_name", { length: 30 }).notNull(),
-  trackName: varchar("track_name", { length: 30 }),
+  name: varchar("name", { length: 100 }).notNull(),
+  shortName: varchar("short_name", { length: 100 }).notNull(),
+  trackName: varchar("track_name", { length: 100 }),
   raceWeek: int("race_week").notNull(),
 
   startTime: varchar("start_time", { length: 30 }).notNull(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -198,18 +198,30 @@ export const seriesWeeklyStatsTable = mysqlTable("series_weekly_stats", {
   id: varchar("id", { length: 21 })
     .primaryKey()
     .$default(() => nanoid()),
-  seriesId: varchar("series_id", { length: 36 })
-    .notNull()
-    .unique()
-    .references(() => seriesTable.seriesId, { onDelete: "cascade" }),
 
+  sessionId: int("session_id").notNull(),
+  subSessionId: int("subsession_id").notNull(),
   seasonYear: int("season_year").notNull(),
   seasonQuarter: int("season_quarter").notNull(),
-  raceWeekNum: int("race_week_num").notNull(),
-  averageEntrants: decimal("average_entrants", { precision: 5, scale: 2 }),
-  averageSplits: decimal("average_splits", { precision: 5, scale: 2 }),
-  totalSplits: int("total_splits"),
+  name: varchar("name", { length: 30 }).notNull(),
+  shortName: varchar("short_name", { length: 30 }).notNull(),
+  trackName: varchar("track_name", { length: 30 }),
+  raceWeek: int("race_week").notNull(),
+
+  startTime: varchar("start_time", { length: 30 }).notNull(),
+  strengthOfField: int("strength_of_field").notNull(), // ← Fixed this
+  totalSplits: int("total_splits").notNull(),
+  totalDrivers: int("total_drivers").notNull(),
+
+  averageEntrants: decimal("average_entrants", {
+    precision: 5,
+    scale: 2,
+  }).notNull(),
+  averageSplits: decimal("average_splits", {
+    precision: 5,
+    scale: 2,
+  }).notNull(),
 
   createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("last_updated").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow().onUpdateNow(),
 });

--- a/src/modules/iracing/schema.ts
+++ b/src/modules/iracing/schema.ts
@@ -30,17 +30,17 @@ export const GetAllSeriesInputSchema = z.object({
   include_series: z.boolean().default(true),
 });
 
-export const GetSeriesResultsInputSchema = z.object({
-  series_id: z.string().nullish(),
-  season_year: z.string(),
-  season_quarter: z.string(),
-  event_types: z.string().nullish(),
-  official_only: z.boolean().nullish(),
-  race_week_num: z.string().nullish(),
-  start_range_begin: z.string().nullish(),
-  start_range_end: z.string().nullish(),
-  cust_id: z.string().nullish(),
-  team_id: z.string().nullish(),
-  category_id: z.string().nullish(),
-  include_series: z.boolean().default(true),
-});
+// export const WeeklyResultsInputSchema = z.object({
+//   series_id: z.string().nullish(),
+//   season_year: z.string(),
+//   season_quarter: z.string(),
+//   event_types: z.string().nullish(),
+//   official_only: z.boolean().nullish(),
+//   race_week_num: z.string().nullish(),
+//   start_range_begin: z.string().nullish(),
+//   start_range_end: z.string().nullish(),
+//   cust_id: z.string().nullish(),
+//   team_id: z.string().nullish(),
+//   category_id: z.string().nullish(),
+//   include_series: z.boolean().default(true),
+// });

--- a/src/modules/iracing/server/helper.ts
+++ b/src/modules/iracing/server/helper.ts
@@ -324,7 +324,7 @@ const cacheWeeklyResults = async ({
       {} as Record<string, SeasonResultsResponse[]>,
     );
 
-    const currentQuarter = Math.ceil(new Date().getMonth() + 1 / 3);
+    const currentQuarter = Math.ceil((new Date().getMonth() + 1) / 3);
 
     const perRaceStats = Object.entries(groupedBySeries).map(
       ([seriesName, sessions]) => {

--- a/src/modules/iracing/server/helper.ts
+++ b/src/modules/iracing/server/helper.ts
@@ -4,7 +4,11 @@ import { eq, gt } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 
 import { db } from "@/db";
-import { iracingAuthTable, seriesTable } from "@/db/schema";
+import {
+  iracingAuthTable,
+  seriesTable,
+  seriesWeeklyStatsTable,
+} from "@/db/schema";
 
 import { COOKIE_EXPIRES_IN_MS, IRACING_URL } from "@/constants";
 
@@ -13,6 +17,8 @@ import {
   TransformLicensesOutput,
   LicenseDiscipline,
   IracingGetAllSeriesResponse,
+  CacheWeeklyResultsInput,
+  SeasonResultsResponse,
 } from "@/modules/iracing/types";
 
 const requiredEnvVars = {
@@ -130,67 +136,6 @@ export const getOrRefreshAuthCode = async () => {
       message: error instanceof Error ? error.message : "Authentication failed",
     });
   }
-};
-
-const transformLicenses = (
-  member: TransformLicensesInput,
-): TransformLicensesOutput => {
-  if (!member?.licenses) {
-    const { licenses, ...restData } = member;
-    return {
-      ...restData,
-      licenses: null,
-    };
-  }
-
-  // Extract the licenses object
-  const licenseData = member.licenses;
-
-  // Create an array of license objects
-  const disciplinesArray: LicenseDiscipline[] = [
-    {
-      category: "Oval",
-      iRating: licenseData.ovalIRating,
-      safetyRating: licenseData.ovalSafetyRating,
-      licenseClass: licenseData.ovalLicenseClass,
-    },
-    {
-      category: "Sports",
-      iRating: licenseData.sportsCarIRating,
-      safetyRating: licenseData.sportsCarSafetyRating,
-      licenseClass: licenseData.sportsCarLicenseClass,
-    },
-    {
-      category: "Formula",
-      iRating: licenseData.formulaCarIRating,
-      safetyRating: licenseData.formulaCarSafetyRating,
-      licenseClass: licenseData.formulaCarLicenseClass,
-    },
-    {
-      category: "Dirt Oval",
-      iRating: licenseData.dirtOvalIRating,
-      safetyRating: licenseData.dirtOvalSafetyRating,
-      licenseClass: licenseData.dirtOvalLicenseClass,
-    },
-    {
-      category: "Dirt Road",
-      iRating: licenseData.dirtRoadIRating,
-      safetyRating: licenseData.dirtRoadSafetyRating,
-      licenseClass: licenseData.dirtRoadLicenseClass,
-    },
-  ];
-
-  // Excluding the old licenses field
-  const { licenses, ...restOfMember } = member;
-
-  return {
-    ...restOfMember,
-    licenses: {
-      id: licenses.id,
-
-      disciplines: disciplinesArray,
-    },
-  };
 };
 
 const fetchData = async ({
@@ -331,4 +276,170 @@ const cacheSeries = async ({ authCode }: { authCode: string }) => {
   }
 };
 
-export { transformLicenses, fetchData, cacheSeries };
+const cacheWeeklyResults = async ({
+  authCode,
+  params,
+}: {
+  authCode: string;
+  params: {
+    season_id: string;
+    event_type: string;
+    race_week_num: string;
+  };
+}) => {
+  try {
+    const weeklyResults = await db
+      .select()
+      .from(seriesWeeklyStatsTable)
+      .where(
+        gt(
+          seriesWeeklyStatsTable.updatedAt,
+          new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+        ),
+      );
+
+    if (weeklyResults.length > 0) {
+      console.log("Using cached weekly results.");
+      return { success: true };
+    }
+
+    console.log("Refreshing weekly results.");
+
+    const allSessions: SeasonResultsResponse[] = await fetchData({
+      query: `/result/season_result&season_id=${params.season_id}&event_type=${params.event_type}&race_week_num=${params.race_week_num}`,
+      authCode: authCode,
+    });
+
+    const groupedBySeries = allSessions.reduce(
+      (obj, session) => {
+        const seriesName = session.car_classes[0].name; // or short_name
+
+        if (!obj[seriesName]) {
+          obj[seriesName] = [];
+        }
+
+        obj[seriesName].push(session);
+        return obj;
+      },
+      {} as Record<string, SeasonResultsResponse[]>,
+    );
+
+    const currentQuarter = Math.ceil(new Date().getMonth() + 1 / 3);
+
+    const perRaceStats = Object.entries(groupedBySeries).map(
+      ([seriesName, sessions]) => {
+        const groupedByStartTime = sessions.reduce(
+          (obj, session) => {
+            if (!obj[session.start_time]) {
+              obj[session.start_time] = [];
+            }
+            obj[session.start_time].push(session);
+            return obj;
+          },
+          {} as Record<string, SeasonResultsResponse[]>,
+        );
+
+        const totalRaces = Object.keys(groupedByStartTime).length;
+        const totalSplits = sessions.length;
+        const totalDrivers = sessions.reduce(
+          (sum, session) => sum + session.num_drivers,
+          0,
+        );
+
+        const averageSplits = (totalSplits / totalRaces).toString();
+        const averageEntrants = (totalDrivers / totalSplits).toString();
+        const seasonYear = new Date(sessions[0].start_time).getFullYear();
+
+        return {
+          sessionId: sessions[0].session_id,
+          subSessionId: sessions[0].subsession_id,
+          seasonYear: seasonYear,
+          seasonQuarter: currentQuarter,
+          name: seriesName,
+          shortName: sessions[0].car_classes[0].short_name,
+          trackName: sessions[0].track.track_name,
+          raceWeek: sessions[0].race_week_num,
+
+          startTime: sessions[0].start_time,
+          strengthOfField: sessions[0].event_strength_of_field,
+          totalSplits,
+          totalDrivers,
+          averageEntrants,
+          averageSplits,
+        };
+      },
+    );
+
+    await db.insert(seriesWeeklyStatsTable).values(perRaceStats);
+
+    return { success: true };
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("Error in cacheWeeklyResults:", error);
+      return { success: false, error: error.message };
+    }
+  }
+};
+
+const transformLicenses = (
+  member: TransformLicensesInput,
+): TransformLicensesOutput => {
+  if (!member?.licenses) {
+    const { licenses, ...restData } = member;
+    return {
+      ...restData,
+      licenses: null,
+    };
+  }
+
+  // Extract the licenses object
+  const licenseData = member.licenses;
+
+  // Create an array of license objects
+  const disciplinesArray: LicenseDiscipline[] = [
+    {
+      category: "Oval",
+      iRating: licenseData.ovalIRating,
+      safetyRating: licenseData.ovalSafetyRating,
+      licenseClass: licenseData.ovalLicenseClass,
+    },
+    {
+      category: "Sports",
+      iRating: licenseData.sportsCarIRating,
+      safetyRating: licenseData.sportsCarSafetyRating,
+      licenseClass: licenseData.sportsCarLicenseClass,
+    },
+    {
+      category: "Formula",
+      iRating: licenseData.formulaCarIRating,
+      safetyRating: licenseData.formulaCarSafetyRating,
+      licenseClass: licenseData.formulaCarLicenseClass,
+    },
+    {
+      category: "Dirt Oval",
+      iRating: licenseData.dirtOvalIRating,
+      safetyRating: licenseData.dirtOvalSafetyRating,
+      licenseClass: licenseData.dirtOvalLicenseClass,
+    },
+    {
+      category: "Dirt Road",
+      iRating: licenseData.dirtRoadIRating,
+      safetyRating: licenseData.dirtRoadSafetyRating,
+      licenseClass: licenseData.dirtRoadLicenseClass,
+    },
+  ];
+
+  // Excluding the old licenses field
+  const { licenses, ...restOfMember } = member;
+
+  return {
+    ...restOfMember,
+    licenses: {
+      id: licenses.id,
+
+      disciplines: disciplinesArray,
+    },
+  };
+};
+
+export { transformLicenses, fetchData, cacheSeries, cacheWeeklyResults };

--- a/src/modules/iracing/server/procedures.ts
+++ b/src/modules/iracing/server/procedures.ts
@@ -18,7 +18,6 @@ import {
 
 import {
   GetAllSeriesInputSchema,
-  GetSeriesResultsInputSchema,
   GetUserInputSchema,
 } from "@/modules/iracing/schema";
 
@@ -98,26 +97,6 @@ export const iracingRouter = createTRPCRouter({
         query: `/data/series/seasons?include_series=${include_series}&season_year=${season_year}&season_quarter=${season_quarter}`,
         authCode: ctx.iracingAuthCode,
       });
-
-      // await Promise.all(
-      //   data.map((item) =>
-      //     db
-      //       .insert(seriesTable)
-      //       .values({
-      //         seriesId: item.series_id.toString(),
-      //         seasonId: item.season_id.toString(),
-      //         seasonYear: item.season_year,
-      //         seasonQuarter: item.season_quarter,
-      //         category: item.schedules[0].category,
-      //         seriesName: item.schedules[0].schedule_name,
-      //         licenseGroup: item.license_group,
-      //         fixedSetup: item.fixed_setup,
-      //       })
-      //       .onDuplicateKeyUpdate({
-      //         set: {},
-      //       }),
-      //   ),
-      // );
 
       return await db.select().from(seriesTable);
     }),
@@ -201,4 +180,8 @@ export const iracingRouter = createTRPCRouter({
 
       return successfulResults;
     }),
+
+  seriesWeeklyResults: iracingProcedure.query(async () => {
+    return await db.select().from(seriesWeeklyStatsTable);
+  }),
 });

--- a/src/modules/iracing/server/procedures.ts
+++ b/src/modules/iracing/server/procedures.ts
@@ -102,83 +102,9 @@ export const iracingRouter = createTRPCRouter({
     }),
 
   getSeriesResults: iracingProcedure
-    .input(GetSeriesResultsInputSchema)
+    .input(GetAllSeriesInputSchema)
     .query(async ({ ctx, input }) => {
-      // Updates every 7 days
-      const weeklyResults = await db
-        .select()
-        .from(seriesWeeklyStatsTable)
-        .where(
-          gt(
-            seriesWeeklyStatsTable.updatedAt,
-            new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
-          ),
-        );
-
-      // if weekly results are valid
-      if (weeklyResults.length > 0) {
-        console.log("Using cached weekly results.");
-        return weeklyResults;
-      }
-
-      console.log("Refreshing weekly results.");
-
-      const paramsArr = ["/data/results/search_series"];
-      Object.entries(input).forEach(([key, value]) => {
-        if (value) {
-          paramsArr.push(`&${key}=${value}`);
-        }
-      });
-      const allSeries = await db.select().from(seriesTable);
-      const params = paramsArr.join("");
-
-      const fetchArr = allSeries.map((series) =>
-        helper.fetchData({
-          query: params + `&series_id=${series.seriesId}`,
-          authCode: ctx.iracingAuthCode,
-        }),
-      );
-
-      const results = await Promise.allSettled(fetchArr);
-
-      const successfulResults: IracingGetSeriesResultsResponse[][] = results
-        .filter((result) => result.status === "fulfilled")
-        .map((result) => result.value);
-
-      const updateWeeklySeries = successfulResults
-        .filter((series) => series.length > 0)
-        .map((series) => {
-          // Group by start_time to count unique races
-          const uniqueRaces = new Set(series.map((split) => split.start_time))
-            .size;
-
-          const avgSplitsPerRace = series.length / uniqueRaces;
-
-          const totalDrivers = series.reduce(
-            (total, split) => total + split.num_drivers,
-            0,
-          );
-
-          const avgEntrants =
-            Math.round((totalDrivers / series.length) * 100) / 100; // Round to 2 decimal
-
-          return db
-            .insert(seriesWeeklyStatsTable)
-            .values({
-              seriesId: series[0].series_id.toString(),
-              seasonYear: series[0].season_year,
-              seasonQuarter: series[0].season_quarter,
-              raceWeekNum: series[0].race_week_num,
-              averageEntrants: avgEntrants.toFixed(5),
-              averageSplits: avgSplitsPerRace.toFixed(5),
-              totalSplits: series.length,
-            })
-            .onDuplicateKeyUpdate({ set: {} });
-        });
-
-      await Promise.all(updateWeeklySeries);
-
-      return successfulResults;
+     // TODO
     }),
 
   seriesWeeklyResults: iracingProcedure.query(async () => {

--- a/src/modules/iracing/types.ts
+++ b/src/modules/iracing/types.ts
@@ -113,8 +113,6 @@ export type TransformLicensesOutput = {
   } | null;
 };
 
-
-
 export type IracingGetSeriesResultsResponse = {
   session_id: number;
   subsession_id: number;
@@ -335,3 +333,67 @@ export type IracingGetAllSeriesResponse = {
 //   track_types: { track_type: string }[];
 //   unsport_conduct_rule_mode: number;
 // }[];
+
+export type CacheWeeklyResultsInput = {
+  authCode: string;
+  params: {
+    series_id: string;
+    season_year: string;
+    season_quarter: string;
+    event_types: string;
+    official_only: boolean;
+    race_week_num: string;
+    start_range_begin: string;
+    start_range_end: string;
+    cust_id: string;
+    team_id: string;
+    category_id: string;
+    include_series: string;
+  };
+};
+
+export type SeasonResultsResponse = {
+  session_id: number;
+  subsession_id: number;
+  race_week_num: number;
+  car_classes: {
+    car_class_id: 74;
+    short_name: string;
+    name: string;
+    num_entries: number;
+    strength_of_field: number;
+  }[];
+  driver_changes: boolean;
+  event_best_lap_time: number;
+  event_strength_of_field: number;
+  event_type: number;
+  event_type_name: string;
+  farm: {
+    farm_id: number;
+    display_name: string;
+    image_path: string;
+    displayed: boolean;
+  };
+  num_caution_laps: number;
+  num_cautions: number;
+  num_drivers: number;
+  num_lead_changes: number;
+  official_session: boolean;
+  start_time: string;
+  track: {
+    config_name: string;
+    track_id: number;
+    track_name: string;
+  };
+  winner_helmet: {
+    pattern: number;
+    color1: string;
+    color2: string;
+    color3: string;
+    face_type: number;
+    helmet_type: number;
+  };
+  winner_id: number;
+  winner_license_level: number;
+  winner_name: string;
+};

--- a/src/modules/iracing/types.ts
+++ b/src/modules/iracing/types.ts
@@ -357,7 +357,7 @@ export type SeasonResultsResponse = {
   subsession_id: number;
   race_week_num: number;
   car_classes: {
-    car_class_id: 74;
+    car_class_id: number;
     short_name: string;
     name: string;
     num_entries: number;


### PR DESCRIPTION
Add cacheWeeklyResults to fetch, process and cache weekly racing data with automatic series statistics calculation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly series results, accessible via a new endpoint.
  * Introduced background caching of weekly results for faster access and fresher data.

* **Chores**
  * Expanded database schema to store richer weekly statistics (names, timing, field strength, splits, drivers, and averages).
  * Improved reliability of background jobs with clearer failure handling and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->