### PR TITLE
Refactor iRacing data handling and database schema updates

### DIFF
--- a/drizzle/0000_wide_karen_page.sql
+++ b/drizzle/0000_wide_karen_page.sql
@@ -1,0 +1,157 @@
+CREATE TABLE IF NOT EXISTS `account` (
+	`id` varchar(36) NOT NULL,
+	`account_id` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`user_id` varchar(36) NOT NULL,
+	`scope` text,
+	`password` text,
+	`id_token` text,
+	`access_token` text,
+	`refresh_token` text,
+	`access_token_expires_at` timestamp,
+	`refresh_token_expires_at` timestamp,
+	`created_at` timestamp NOT NULL,
+	`updated_at` timestamp NOT NULL,
+	CONSTRAINT `account_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `iracing_auth` (
+	`id` varchar(21) NOT NULL,
+	`auth_code` text NOT NULL,
+	`sso_cookie_value` text,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	`expires_at` timestamp,
+	CONSTRAINT `iracing_auth_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `license` (
+	`id` varchar(21) NOT NULL,
+	`user_id` varchar(36) NOT NULL,
+	`oval_i_rating` int,
+	`oval_safety_rating` decimal(4,2),
+	`oval_license_class` enum('A','B','C','D','R') NOT NULL DEFAULT 'R',
+	`sports_car_i_rating` int,
+	`sports_car_safety_rating` decimal(4,2),
+	`sports_license_class` enum('A','B','C','D','R') NOT NULL DEFAULT 'R',
+	`formula_car_i_rating` int,
+	`formula_car_safety_rating` decimal(4,2),
+	`formula_license_class` enum('A','B','C','D','R') NOT NULL DEFAULT 'R',
+	`dirt_oval_i_rating` int,
+	`dirt_oval_safety_rating` decimal(4,2),
+	`dirt_oval_license_class` enum('A','B','C','D','R') NOT NULL DEFAULT 'R',
+	`dirt_road_i_rating` int,
+	`dirt_road_safety_rating` decimal(4,2),
+	`dirt_road_license_class` enum('A','B','C','D','R') NOT NULL DEFAULT 'R',
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `license_id` PRIMARY KEY(`id`),
+	CONSTRAINT `license_user_id_unique` UNIQUE(`user_id`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `profile` (
+	`id` varchar(21) NOT NULL,
+	`user_id` varchar(36) NOT NULL,
+	`iracing_id` varchar(10),
+	`is_active` boolean NOT NULL DEFAULT false,
+	`discord` varchar(37) DEFAULT '',
+	`team` varchar(20) DEFAULT '',
+	`bio` text DEFAULT (''),
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `profile_id` PRIMARY KEY(`id`),
+	CONSTRAINT `profile_user_id_unique` UNIQUE(`user_id`),
+	CONSTRAINT `profile_iracing_id_unique` UNIQUE(`iracing_id`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `series` (
+	`series_id` int NOT NULL,
+	`category` varchar(25) NOT NULL,
+	`series_name` varchar(100) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `series_series_id` PRIMARY KEY(`series_id`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `series_weekly_stats` (
+	`id` varchar(21) NOT NULL,
+	`series_id` int,
+	`season_id` int,
+	`session_id` int NOT NULL,
+	`name` varchar(100) NOT NULL,
+	`season_year` int NOT NULL,
+	`season_quarter` int NOT NULL,
+	`race_week` int NOT NULL,
+	`track_name` varchar(100),
+	`start_time` varchar(30) NOT NULL,
+	`total_splits` int NOT NULL,
+	`total_drivers` int NOT NULL,
+	`strength_of_field` int NOT NULL,
+	`average_entrants` decimal(5,2) NOT NULL,
+	`average_splits` decimal(5,2) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `series_weekly_stats_id` PRIMARY KEY(`id`),
+	CONSTRAINT `series_weekly_stats_session_id_unique` UNIQUE(`session_id`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `session` (
+	`id` varchar(36) NOT NULL,
+	`user_id` varchar(36) NOT NULL,
+	`token` varchar(255) NOT NULL,
+	`ip_address` text,
+	`user_agent` text,
+	`impersonated_by` text,
+	`expires_at` timestamp NOT NULL,
+	`created_at` timestamp NOT NULL,
+	`updated_at` timestamp NOT NULL,
+	CONSTRAINT `session_id` PRIMARY KEY(`id`),
+	CONSTRAINT `session_token_unique` UNIQUE(`token`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `user` (
+	`id` varchar(36) NOT NULL,
+	`name` text NOT NULL,
+	`email` varchar(255) NOT NULL,
+	`email_verified` boolean NOT NULL,
+	`image` text,
+	`role` enum('admin','staff','member') NOT NULL DEFAULT 'member',
+	`banned` boolean,
+	`ban_reason` text,
+	`ban_expires` timestamp,
+	`created_at` timestamp NOT NULL,
+	`updated_at` timestamp NOT NULL,
+	CONSTRAINT `user_id` PRIMARY KEY(`id`),
+	CONSTRAINT `user_email_unique` UNIQUE(`email`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `user_chart_data` (
+	`id` varchar(21) NOT NULL,
+	`user_id` varchar(36) NOT NULL,
+	`category_id` int,
+	`category` varchar(50) NOT NULL,
+	`chart_type` varchar(50) NOT NULL,
+	`when` date NOT NULL,
+	`value` int NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `user_chart_data_id` PRIMARY KEY(`id`),
+	CONSTRAINT `user_chart_data_user_id_category_chart_type_when_unique` UNIQUE(`user_id`,`category`,`chart_type`,`when`)
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `verification` (
+	`id` varchar(36) NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` timestamp NOT NULL,
+	`created_at` timestamp,
+	`updated_at` timestamp,
+	CONSTRAINT `verification_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+ALTER TABLE `account` ADD CONSTRAINT `account_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `license` ADD CONSTRAINT `license_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `profile` ADD CONSTRAINT `profile_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `series_weekly_stats` ADD CONSTRAINT `series_weekly_stats_series_id_series_series_id_fk` FOREIGN KEY (`series_id`) REFERENCES `series`(`series_id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `session` ADD CONSTRAINT `session_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `user_chart_data` ADD CONSTRAINT `user_chart_data_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1078 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "1064008c-a7eb-428a-acc3-16577d101444",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_id": {
+          "name": "account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "iracing_auth": {
+      "name": "iracing_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_code": {
+          "name": "auth_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sso_cookie_value": {
+          "name": "sso_cookie_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "iracing_auth_id": {
+          "name": "iracing_auth_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "license": {
+      "name": "license",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "oval_i_rating": {
+          "name": "oval_i_rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oval_safety_rating": {
+          "name": "oval_safety_rating",
+          "type": "decimal(4,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oval_license_class": {
+          "name": "oval_license_class",
+          "type": "enum('A','B','C','D','R')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'R'"
+        },
+        "sports_car_i_rating": {
+          "name": "sports_car_i_rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sports_car_safety_rating": {
+          "name": "sports_car_safety_rating",
+          "type": "decimal(4,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sports_license_class": {
+          "name": "sports_license_class",
+          "type": "enum('A','B','C','D','R')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'R'"
+        },
+        "formula_car_i_rating": {
+          "name": "formula_car_i_rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "formula_car_safety_rating": {
+          "name": "formula_car_safety_rating",
+          "type": "decimal(4,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "formula_license_class": {
+          "name": "formula_license_class",
+          "type": "enum('A','B','C','D','R')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'R'"
+        },
+        "dirt_oval_i_rating": {
+          "name": "dirt_oval_i_rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dirt_oval_safety_rating": {
+          "name": "dirt_oval_safety_rating",
+          "type": "decimal(4,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dirt_oval_license_class": {
+          "name": "dirt_oval_license_class",
+          "type": "enum('A','B','C','D','R')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'R'"
+        },
+        "dirt_road_i_rating": {
+          "name": "dirt_road_i_rating",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dirt_road_safety_rating": {
+          "name": "dirt_road_safety_rating",
+          "type": "decimal(4,2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dirt_road_license_class": {
+          "name": "dirt_road_license_class",
+          "type": "enum('A','B','C','D','R')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'R'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "license_user_id_user_id_fk": {
+          "name": "license_user_id_user_id_fk",
+          "tableFrom": "license",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "license_id": {
+          "name": "license_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "license_user_id_unique": {
+          "name": "license_user_id_unique",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "profile": {
+      "name": "profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iracing_id": {
+          "name": "iracing_id",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "discord": {
+          "name": "discord",
+          "type": "varchar(37)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "team": {
+          "name": "team",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('')"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profile_id": {
+          "name": "profile_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "profile_user_id_unique": {
+          "name": "profile_user_id_unique",
+          "columns": [
+            "user_id"
+          ]
+        },
+        "profile_iracing_id_unique": {
+          "name": "profile_iracing_id_unique",
+          "columns": [
+            "iracing_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "series_id": {
+          "name": "series_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_name": {
+          "name": "series_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "series_series_id": {
+          "name": "series_series_id",
+          "columns": [
+            "series_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "series_weekly_stats": {
+      "name": "series_weekly_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "season_id": {
+          "name": "season_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_year": {
+          "name": "season_year",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_quarter": {
+          "name": "season_quarter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "race_week": {
+          "name": "race_week",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_splits": {
+          "name": "total_splits",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_drivers": {
+          "name": "total_drivers",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strength_of_field": {
+          "name": "strength_of_field",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_entrants": {
+          "name": "average_entrants",
+          "type": "decimal(5,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "average_splits": {
+          "name": "average_splits",
+          "type": "decimal(5,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "series_weekly_stats_series_id_series_series_id_fk": {
+          "name": "series_weekly_stats_series_id_series_series_id_fk",
+          "tableFrom": "series_weekly_stats",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "series_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "series_weekly_stats_id": {
+          "name": "series_weekly_stats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "series_weekly_stats_session_id_unique": {
+          "name": "series_weekly_stats_session_id_unique",
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "session_id": {
+          "name": "session_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('admin','staff','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "user_chart_data": {
+      "name": "user_chart_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "when": {
+          "name": "when",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_chart_data_user_id_user_id_fk": {
+          "name": "user_chart_data_user_id_user_id_fk",
+          "tableFrom": "user_chart_data",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_chart_data_id": {
+          "name": "user_chart_data_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "user_chart_data_user_id_category_chart_type_when_unique": {
+          "name": "user_chart_data_user_id_category_chart_type_when_unique",
+          "columns": [
+            "user_id",
+            "category",
+            "chart_type",
+            "when"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_id": {
+          "name": "verification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1756269128594,
+      "tag": "0000_wide_karen_page",
+      "breakpoints": true
+    }
+  ]
+}

--- a/mark_migration_complete.sql
+++ b/mark_migration_complete.sql
@@ -1,0 +1,17 @@
+-- Mark the Drizzle migration as completed
+-- Run this AFTER successfully applying selective_migration.sql
+
+-- First, check if __drizzle_migrations table exists, if not create it
+CREATE TABLE IF NOT EXISTS `__drizzle_migrations` (
+    `id` SERIAL PRIMARY KEY,
+    `hash` text NOT NULL,
+    `created_at` bigint
+);
+
+-- Mark the migration as completed
+-- Replace 'naive_slyde' with the actual hash from your migration file
+INSERT INTO `__drizzle_migrations` (`hash`, `created_at`) 
+VALUES ('naive_slyde', UNIX_TIMESTAMP() * 1000)
+ON DUPLICATE KEY UPDATE `created_at` = `created_at`;
+
+SELECT 'Migration marked as complete' as status;

--- a/rollback_migration.sql
+++ b/rollback_migration.sql
@@ -1,0 +1,22 @@
+-- Rollback Script
+-- Use this ONLY if the selective migration fails and you need to revert changes
+
+-- Step 1: Drop foreign key constraint
+ALTER TABLE `series_weekly_stats` DROP FOREIGN KEY IF EXISTS `series_weekly_stats_series_id_series_series_id_fk`;
+
+-- Step 2: Revert series_weekly_stats columns back to varchar
+ALTER TABLE `series_weekly_stats` MODIFY COLUMN `series_id` varchar(36);
+ALTER TABLE `series_weekly_stats` MODIFY COLUMN `season_id` varchar(100);
+ALTER TABLE `series_weekly_stats` MODIFY COLUMN `session_id` varchar(100) NOT NULL;
+
+-- Step 3: Revert series.series_id back to varchar
+ALTER TABLE `series` MODIFY COLUMN `series_id` varchar(36) NOT NULL;
+
+-- Step 4: Re-create foreign key constraint with varchar reference
+ALTER TABLE `series_weekly_stats` ADD CONSTRAINT `series_weekly_stats_series_id_series_series_id_fk` 
+FOREIGN KEY (`series_id`) REFERENCES `series`(`series_id`) ON DELETE cascade ON UPDATE no action;
+
+-- Step 5: Drop user_chart_data table if needed
+-- DROP TABLE IF EXISTS `user_chart_data`;
+
+SELECT 'Rollback completed' as status;

--- a/selective_migration.sql
+++ b/selective_migration.sql
@@ -1,0 +1,41 @@
+-- Selective Migration Script
+-- Apply only the changes needed without recreating existing tables
+
+-- Step 1: Create user_chart_data table (if it doesn't exist)
+CREATE TABLE IF NOT EXISTS `user_chart_data` (
+	`id` varchar(21) NOT NULL,
+	`user_id` varchar(36) NOT NULL,
+	`category_id` int,
+	`category` varchar(50) NOT NULL,
+	`chart_type` varchar(50) NOT NULL,
+	`when` date NOT NULL,
+	`value` int NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `user_chart_data_id` PRIMARY KEY(`id`),
+	CONSTRAINT `user_chart_data_user_id_category_chart_type_when_unique` UNIQUE(`user_id`,`category`,`chart_type`,`when`)
+);
+
+-- Step 2: Add foreign key constraint for user_chart_data (if table was just created)
+-- This will fail gracefully if constraint already exists
+ALTER TABLE `user_chart_data` ADD CONSTRAINT `user_chart_data_user_id_user_id_fk` 
+FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE cascade ON UPDATE no action;
+
+-- Step 3: Modify series table - change series_id from varchar to int
+-- First, drop foreign key constraints that reference series_id
+ALTER TABLE `series_weekly_stats` DROP FOREIGN KEY IF EXISTS `series_weekly_stats_series_id_series_series_id_fk`;
+
+-- Change series.series_id from varchar to int
+ALTER TABLE `series` MODIFY COLUMN `series_id` int NOT NULL;
+
+-- Step 4: Modify series_weekly_stats table - change varchar columns to int
+ALTER TABLE `series_weekly_stats` MODIFY COLUMN `series_id` int;
+ALTER TABLE `series_weekly_stats` MODIFY COLUMN `season_id` int;
+ALTER TABLE `series_weekly_stats` MODIFY COLUMN `session_id` int NOT NULL;
+
+-- Step 5: Re-create foreign key constraint
+ALTER TABLE `series_weekly_stats` ADD CONSTRAINT `series_weekly_stats_series_id_series_series_id_fk` 
+FOREIGN KEY (`series_id`) REFERENCES `series`(`series_id`) ON DELETE cascade ON UPDATE no action;
+
+-- Step 6: Verify changes
+SELECT 'Migration completed successfully' as status;

--- a/src/modules/iracing/server/helper.ts
+++ b/src/modules/iracing/server/helper.ts
@@ -269,7 +269,7 @@ const cacheSeries = async ({ authCode }: { authCode: string }) => {
     }
 
     const insertValues = data.map((item) => ({
-      seriesId: item.series_id.toString(),
+      seriesId: item.series_id,
       category: item.category,
       seriesName: item.series_name,
     }));
@@ -484,9 +484,9 @@ const cacheWeeklyResults = async ({
           totalSplits > 0 ? (totalDrivers / totalSplits).toFixed(2) : "0";
 
         return {
-          seriesId: series[0].series_id.toString(),
-          seasonId: series[0].season_id.toString(),
-          sessionId: series[0].session_id.toString(),
+          seriesId: series[0].series_id,
+          seasonId: series[0].season_id,
+          sessionId: series[0].session_id,
           name: series[0].series_name.trim(),
           seasonYear: series[0].season_year,
           seasonQuarter: series[0].season_quarter,

--- a/src/modules/iracing/server/procedures.ts
+++ b/src/modules/iracing/server/procedures.ts
@@ -1,4 +1,4 @@
-import { like, desc, eq, getTableColumns, or, count } from "drizzle-orm";
+import { like, desc, eq, getTableColumns, or, count, and } from "drizzle-orm";
 
 import { TRPCError } from "@trpc/server";
 import {
@@ -14,6 +14,7 @@ import {
   seriesTable,
   seriesWeeklyStatsTable,
   user,
+  userChartDataTable,
 } from "@/db/schema";
 
 import { GetUserInputSchema } from "@/modules/iracing/schema";
@@ -21,6 +22,7 @@ import { GetUserInputSchema } from "@/modules/iracing/schema";
 import * as helper from "@/modules/iracing/server/helper";
 
 import { WeeklySeriesResultsInput } from "@/modules/home/schemas";
+import z from "zod";
 
 export const iracingRouter = createTRPCRouter({
   getDocumentation: iracingProcedure.query(async ({ ctx }) => {
@@ -94,6 +96,22 @@ export const iracingRouter = createTRPCRouter({
       });
     }
   }),
+
+  userChartData: iracingProcedure
+    .input(z.object({ custId: z.string(), categoryId: z.int() }))
+    .query(async ({ ctx, input }) => {
+      const chartData = await db
+        .select()
+        .from(userChartDataTable)
+        .where(
+          and(
+            eq(userChartDataTable.userId, ctx.auth.user.id),
+            eq(userChartDataTable.categoryId, input.categoryId),
+          ),
+        );
+
+      return;
+    }),
 
   weeklySeriesResults: iracingProcedure
     .input(WeeklySeriesResultsInput)


### PR DESCRIPTION
- Updated `series_id`, `season_id`, and `session_id` fields in helper functions to use integer types instead of strings.
- Introduced a new procedure `userChartData` to fetch user chart data based on `custId` and `categoryId`.
- Created new `user_chart_data` table with appropriate constraints and foreign keys.
- Modified existing tables to change `series_id`, `season_id`, and `session_id` from varchar to int.
- Added migration scripts for selective migration, rollback, and marking migration completion.
- Updated database snapshot and journal files to reflect the new schema changes.