### PR TITLE
refactor: extract session logic into reusable getSession utility

### DIFF
--- a/src/app/(dashboard)/manage/page.tsx
+++ b/src/app/(dashboard)/manage/page.tsx
@@ -1,5 +1,4 @@
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
@@ -10,7 +9,7 @@ import { getQueryClient, trpc } from "@/trpc/server";
 
 import { loadSearchParams } from "@/modules/manage/server/procedures/get-users/params";
 
-import { auth } from "@/lib/auth";
+import { getSession } from "@/lib/get-session";
 
 import {
   ManageErrorPage,
@@ -23,11 +22,8 @@ interface ManagePageProps {
 }
 
 const ManagePage = async ({ searchParams }: ManagePageProps) => {
-  const session = await auth.api.getSession({ headers: await headers() });
-
-  if (!session) {
-    redirect("/sign-in");
-  }
+  const session = await getSession();
+  if (!session) redirect("/sign-in");
 
   if (session.user?.role !== "admin" && session.user?.role !== "staff") {
     redirect("/");

--- a/src/app/(dashboard)/members/[memberId]/page.tsx
+++ b/src/app/(dashboard)/members/[memberId]/page.tsx
@@ -1,9 +1,8 @@
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
-import { auth } from "@/lib/auth";
+import { getSession } from "@/lib/get-session";
 
 import { getQueryClient, trpc } from "@/trpc/server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
@@ -19,7 +18,7 @@ interface MemberIdPageProps {
 }
 
 const MemberIdPage = async ({ params }: MemberIdPageProps) => {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const session = await getSession();
   if (!session) redirect("/sign-in");
 
   const { memberId } = await params;

--- a/src/app/(dashboard)/members/page.tsx
+++ b/src/app/(dashboard)/members/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { SearchParams } from "nuqs";
@@ -9,7 +8,7 @@ import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { getQueryClient, trpc } from "@/trpc/server";
 
-import { auth } from "@/lib/auth";
+import { getSession } from "@/lib/get-session";
 
 import { loadSearchParams } from "@/modules/members/server/procedures/get-many/params";
 
@@ -26,8 +25,7 @@ interface MembersPageProps {
 }
 
 const MembersPage = async ({ searchParams }: MembersPageProps) => {
-  const session = await auth.api.getSession({ headers: await headers() });
-
+  const session = await getSession();
   if (!session) redirect("/sign-in");
 
   const filters = await loadSearchParams(searchParams);

--- a/src/app/(dashboard)/profile/page.tsx
+++ b/src/app/(dashboard)/profile/page.tsx
@@ -1,13 +1,12 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 
 import { ErrorBoundary } from "react-error-boundary";
 
-import { auth } from "@/lib/auth";
-
-import { getQueryClient, trpc } from "@/trpc/server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { getQueryClient, trpc } from "@/trpc/server";
+
+import { getSession } from "@/lib/get-session";
 
 import {
   ErrorProfileView,
@@ -16,8 +15,7 @@ import {
 } from "@/modules/profile/ui/views/profile-view";
 
 const ProfilePage = async () => {
-  const session = await auth.api.getSession({ headers: await headers() });
-
+  const session = await getSession();
   if (!session) redirect("/sign-in");
 
   const queryClient = getQueryClient();

--- a/src/app/(dashboard)/schedule/page.tsx
+++ b/src/app/(dashboard)/schedule/page.tsx
@@ -1,15 +1,15 @@
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 
 import { DateTime } from "luxon";
 
-import { SchedulePageView } from "@/modules/schedule/ui/views/schedule-page-view";
-import { auth } from "@/lib/auth";
+import { getSession } from "@/lib/get-session";
+
 import { getQueryClient, trpc } from "@/trpc/server";
 
-const SchedulePage = async () => {
-  const session = await auth.api.getSession({ headers: await headers() });
+import { SchedulePageView } from "@/modules/schedule/ui/views/schedule-page-view";
 
+const SchedulePage = async () => {
+  const session = await getSession();
   if (!session) redirect("/sign-in");
 
   const dt = DateTime.now();

--- a/src/app/(dashboard)/series-stats/page.tsx
+++ b/src/app/(dashboard)/series-stats/page.tsx
@@ -2,7 +2,6 @@ import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 
 import { SearchParams } from "nuqs";
 
@@ -11,7 +10,7 @@ import { getQueryClient, trpc } from "@/trpc/server";
 
 import { loadSearchParams } from "@/modules/iracing/server/procedures/weekly-series-results/params";
 
-import { auth } from "@/lib/auth";
+import { getSession } from "@/lib/get-session";
 
 import { SeriesStatsHeader } from "@/modules/home/ui/components/home-header";
 import {
@@ -25,8 +24,7 @@ interface HomePageProps {
 }
 
 const SeriesStatsPage = async ({ searchParams }: HomePageProps) => {
-  const session = await auth.api.getSession({ headers: await headers() });
-
+  const session = await getSession();
   if (!session) redirect("/sign-in");
 
   const filters = await loadSearchParams(searchParams);

--- a/src/app/(dashboard)/teams/page.tsx
+++ b/src/app/(dashboard)/teams/page.tsx
@@ -1,8 +1,18 @@
-import React from "react";
+import { redirect } from "next/navigation";
+
+import { getSession } from "@/lib/get-session";
+
 import { UnderConstruction } from "@/components/under-construction";
 
-const TeamsPage = () => {
-  return <UnderConstruction title="Teams" message="Team management features are coming soon. Stay tuned for collaboration tools!" />;
+const TeamsPage = async () => {
+  const session = await getSession();
+  if (!session) redirect("/sign-in");
+  return (
+    <UnderConstruction
+      title="Teams"
+      message="Team management features are coming soon. Stay tuned for collaboration tools!"
+    />
+  );
 };
 
 export default TeamsPage;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -51,3 +51,6 @@ export const auth = betterAuth({
     }),
   ],
 });
+
+export type Session = typeof auth.$Infer.Session;
+export type User = typeof auth.$Infer.Session.user;

--- a/src/lib/get-session.ts
+++ b/src/lib/get-session.ts
@@ -1,0 +1,8 @@
+import { cache } from "react";
+import { headers } from "next/headers";
+
+import { auth } from "./auth";
+
+export const getSession = cache(async () => {
+  return auth.api.getSession({ headers: await headers() });
+});

--- a/src/modules/dashboard/ui/components/dashboard-sidebar.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-sidebar.tsx
@@ -1,16 +1,14 @@
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getQueryClient, trpc } from "@/trpc/server";
 
-import { auth } from "@/lib/auth";
+import { getSession } from "@/lib/get-session";
 
 import { DashboardMenu } from "./dashboard-menu";
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export const DashboardSidebar = async () => {
-  const session = await auth.api.getSession({ headers: await headers() });
-
+  const session = await getSession();
   if (!session) redirect("/sign-in");
 
   const queryClient = getQueryClient();

--- a/src/modules/iracing/server/procedures/cache-all-series/index.ts
+++ b/src/modules/iracing/server/procedures/cache-all-series/index.ts
@@ -1,4 +1,3 @@
-import z from "zod";
 import { DateTime } from "luxon";
 
 import { gt } from "drizzle-orm";
@@ -6,11 +5,10 @@ import { gt } from "drizzle-orm";
 import { iracingProcedure } from "@/trpc/init";
 
 import { db } from "@/db";
-
-import { fetchData } from "@/modules/iracing/server/api";
-
 import { seriesTable } from "@/db/schemas";
 import { IRacingGetAllSeriesResponseSchema } from "./schema";
+
+import { fetchData } from "@/modules/iracing/server/api";
 
 export const cacheAllSeries = iracingProcedure.query(async ({ ctx }) => {
   const cachedSeries = await db


### PR DESCRIPTION
  - Create centralized getSession utility with caching
  - Replace auth.api.getSession calls across dashboard pages
  - Remove redundant headers imports from dashboard routes
  - Add type exports for Session and User from auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teams page now requires sign-in before access.

* **Refactor**
  * Unified session handling across dashboard pages for consistent authentication checks.
  * Standardized redirect to sign-in when no session is present.
  * No changes to page content or layouts; existing data loading and rendering remain unchanged.

* **Chores**
  * Added shared session types for internal consistency (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->