### PR TITLE
 Refactor schedule dialog to support both create and edit modes

### DIFF
--- a/src/app/(dashboard)/schedule/layout.tsx
+++ b/src/app/(dashboard)/schedule/layout.tsx
@@ -1,3 +1,3 @@
 export default function Schedulelayout({ children }: LayoutProps<"/schedule">) {
-  return <div className="mx-auto w-[90%] py-8">{children}</div>;
+  return <div className="mx-auto w-[98%] py-8">{children}</div>;
 }

--- a/src/modules/schedule/server/procedures/league-schedule/create/index.ts
+++ b/src/modules/schedule/server/procedures/league-schedule/create/index.ts
@@ -1,4 +1,3 @@
-import { eq } from "drizzle-orm";
 
 import { TRPCError } from "@trpc/server";
 import { protectedProcedure } from "@/trpc/init";
@@ -11,26 +10,22 @@ import { CreateLeagueScheduleInputSchema } from "./schema";
 export const createLeagueScheduleProcedure = protectedProcedure
   .input(CreateLeagueScheduleInputSchema)
   .mutation(async ({ input }) => {
-    const { scheduleId, seasonNumber, trackName, temp, raceLength, date } =
-      input;
+    const { seasonNumber, trackName, temp, raceLength, date } = input;
 
     try {
-      await db
-        .update(leagueScheduleTable)
-        .set({
-          seasonNumber,
-          trackName,
-          temp,
-          raceLength,
-          date,
-        })
-        .where(eq(leagueScheduleTable.id, scheduleId));
+      await db.insert(leagueScheduleTable).values({
+        seasonNumber,
+        trackName,
+        temp,
+        raceLength,
+        date: new Date(date),
+      });
       return { success: true, error: null };
     } catch (error) {
-      console.error("Database error while updating schedule:", error);
+      console.error("Database error while creating schedule:", error);
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
-        message: "Failed to update league schedule.",
+        message: "Failed to create league schedule.",
       });
     }
   });

--- a/src/modules/schedule/server/procedures/league-schedule/create/schema.ts
+++ b/src/modules/schedule/server/procedures/league-schedule/create/schema.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
 
 export const CreateLeagueScheduleInputSchema = z.object({
-  scheduleId: z.string().min(1, "Schedule ID required."),
-  seasonNumber: z.int().min(1, "Season number required."),
+  seasonNumber: z.number().min(1, "Season number required."),
   trackName: z.string().min(1, "Track name required."),
   temp: z.number().min(1, "Temperature required."),
   raceLength: z.number().min(1, "Race length required."),
-  date: z.date().min(1, "Date Required."),
+  date: z.string().min(1, "Date Required."),
 });

--- a/src/modules/schedule/server/procedures/league-schedule/edit/index.ts
+++ b/src/modules/schedule/server/procedures/league-schedule/edit/index.ts
@@ -1,4 +1,3 @@
-import { DateTime } from "luxon";
 
 import { eq } from "drizzle-orm";
 
@@ -13,17 +12,17 @@ import { EditLeagueScheduleSchema } from "./schema";
 export const editLeagueScheduleProcedure = protectedProcedure
   .input(EditLeagueScheduleSchema)
   .mutation(async ({ input }) => {
-    const { scheduleId, track, temp, raceLength, date } = input;
+    const { scheduleId, seasonNumber, trackName, temp, raceLength, date } = input;
 
-    const formatDate = DateTime.now().toJSDate();
     try {
       await db
         .update(leagueScheduleTable)
         .set({
-          track,
+          seasonNumber,
+          trackName,
           temp,
           raceLength,
-          date: formatDate, // change later
+          date: new Date(date),
         })
         .where(eq(leagueScheduleTable.id, scheduleId));
       return { success: true, error: null };

--- a/src/modules/schedule/server/procedures/league-schedule/edit/schema.ts
+++ b/src/modules/schedule/server/procedures/league-schedule/edit/schema.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 
 export const LeagueScheduleSchema = z.object({
-  seasonNumber: z.int(),
-  trackName: z.string(),
-  temp: z.number(),
-  raceLength: z.number(),
-  date: z.string(),
+  seasonNumber: z.number().min(1, "Season number required."),
+  trackName: z.string().min(1, "Track name required."),
+  temp: z.number().min(1, "Temperature required."),
+  raceLength: z.number().min(1, "Race length required."),
+  date: z.string().min(1, "Date required."),
 });
 
 export const EditLeagueScheduleSchema = LeagueScheduleSchema.extend({

--- a/src/modules/schedule/ui/components/form/form-actions.tsx
+++ b/src/modules/schedule/ui/components/form/form-actions.tsx
@@ -3,9 +3,25 @@ import { Button } from "@/components/ui/button";
 interface FormActions {
   isPending: boolean;
   onCloseDialog: () => void;
+  mode: "Create" | "Edit";
 }
 
-export const FormActions = ({ isPending, onCloseDialog }: FormActions) => {
+export const FormActions = ({
+  isPending,
+  onCloseDialog,
+  mode,
+}: FormActions) => {
+  const label = mode === "Create" ? "Create" : "Update";
+
+  const submitLabel = isPending ? (
+    <div className="flex items-center gap-2">
+      <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+      {mode === "Create" ? "Creating..." : "Updating..."}
+    </div>
+  ) : (
+    label
+  );
+
   return (
     <div className="flex items-center justify-between gap-3 p-6 pt-4 dark:border-gray-700 dark:bg-gray-800/50">
       <Button
@@ -17,20 +33,14 @@ export const FormActions = ({ isPending, onCloseDialog }: FormActions) => {
       >
         Cancel
       </Button>
+
       <Button
         type="submit"
         size="lg"
         disabled={isPending}
         className="bg-blue-600 px-8 py-2 font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
-        {isPending ? (
-          <div className="flex items-center gap-2">
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-            Updating...
-          </div>
-        ) : (
-          "Update"
-        )}
+        {submitLabel}
       </Button>
     </div>
   );

--- a/src/modules/schedule/ui/components/league-schedule-content.tsx
+++ b/src/modules/schedule/ui/components/league-schedule-content.tsx
@@ -1,13 +1,20 @@
 import { useState } from "react";
 
-import { cn } from "@/lib/utils";
+import { toast } from "sonner";
 
 import { Edit3, Trash } from "lucide-react";
 
-import type { LeagueSchedules } from "@/modules/schedule/server/procedures/league-schedule/get-many/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "@/trpc/client";
 
-import { EditLeagueScheduleDialog } from "./form/edit-schedule-dialog";
-import { LeagueSchedule } from "../../server/procedures/league-schedule/get-one/types";
+import { cn } from "@/lib/utils";
+
+import { useConfirm } from "@/hooks/use-confirm";
+
+import { LeagueScheduleDialog } from "./form/league-schedule-dialog";
+
+import type { LeagueSchedules } from "@/modules/schedule/server/procedures/league-schedule/get-many/types";
+import type { LeagueSchedule } from "@/modules/schedule/server/procedures/league-schedule/get-one/types";
 
 import { TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
@@ -20,116 +27,79 @@ import {
 } from "@/components/ui/card";
 
 interface LeagueScheduleContentProps {
-  scheduleList?: LeagueSchedules;
+  scheduleList: LeagueSchedules;
   isAdmin: boolean;
 }
-
-// Dummy data for testing
-const dummyScheduleList = [
-  {
-    id: "1",
-    seasonNumber: 1,
-    trackName: "INDIANAPOLIS MOTOR SPEEDWAY - ROAD COURSE",
-    raceLength: 45,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    temp: 68,
-    date: new Date("2024-10-19T21:55:00Z"),
-  },
-  {
-    id: "2",
-    seasonNumber: 1,
-    trackName: "HOCKENHEIMRING - GRAND PRIX",
-    raceLength: 45,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    temp: 65,
-    date: new Date("2024-10-26T16:00:00Z"),
-  },
-  {
-    id: "3",
-    seasonNumber: 1,
-    trackName: "SEBRING INTERNATIONAL RACEWAY - INTERNATIONAL",
-    raceLength: 45,
-    temp: 78,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    date: new Date("2024-11-02T18:10:00Z"),
-  },
-  {
-    id: "4",
-    seasonNumber: 1,
-    trackName: "AUTODROMO JOSE CARLOS PACE - GRAND PRIX",
-    raceLength: 45,
-    temp: 67,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    date: new Date("2024-11-09T21:20:00Z"),
-  },
-  {
-    id: "5",
-    seasonNumber: 1,
-    trackName: "SUZUKA INTERNATIONAL RACING COURSE - GRAND PRIX",
-    raceLength: 45,
-    temp: 66,
-    date: new Date("2024-11-16T11:20:00Z"),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  },
-  {
-    id: "6",
-    seasonNumber: 1,
-    trackName: "MOUNT PANORAMA CIRCUIT",
-    raceLength: 45,
-    temp: 77,
-    date: new Date("2024-11-23T16:00:00Z"),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  },
-  {
-    id: "7",
-    seasonNumber: 1,
-    trackName: "WATKINS GLEN INTERNATIONAL - BOOT",
-    raceLength: 45,
-    temp: 65,
-    date: new Date("2024-11-30T18:30:00Z"),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  },
-  {
-    id: "8",
-    seasonNumber: 1,
-    trackName: "AUTODROMO MUGELLO - GRAND PRIX",
-    raceLength: 60,
-    temp: 66,
-    date: new Date("2024-12-07T16:00:00Z"),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  },
-] as LeagueSchedules;
 
 export const LeagueScheduleContent = ({
   scheduleList,
   isAdmin,
 }: LeagueScheduleContentProps) => {
+  const [isOpen, setIsOpen] = useState(false);
   const [selectedSchedule, setSelectedSchedule] =
     useState<LeagueSchedule | null>(null);
-  const [isOpen, setIsOpen] = useState(false);
+  const [mode, setMode] = useState<"Create" | "Edit">("Create");
 
-  const onEdit = (schedule: LeagueSchedule) => {
-    setSelectedSchedule(schedule);
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const deleteSchedule = useMutation(
+    trpc.schedule.deleteLeagueSchedule.mutationOptions({
+      onSuccess: async (data) => {
+        await queryClient.invalidateQueries(
+          trpc.schedule.getLeagueSchedules.queryOptions(),
+        );
+
+        toast.success("Schedule successfully deleted.");
+      },
+      onError: () => {
+        toast.error("Something went wrong deleting schedule.");
+      },
+    }),
+  );
+
+  const [ConfirmationDialog, confirmDelete] = useConfirm({
+    title: "Delete Schedule",
+    description: "Are you sure? This action can't be undone.",
+  });
+
+  const onDelete = async (scheduleId: string) => {
+    const OK = await confirmDelete();
+    if (!OK) return;
+
+    deleteSchedule.mutate({ scheduleId });
+  };
+
+  const onSubmit = ({
+    schedule,
+    mode,
+  }: {
+    schedule?: LeagueSchedule;
+    mode: "Create" | "Edit";
+  }) => {
+    setMode(mode);
+
+    if (schedule && mode === "Edit") {
+      setSelectedSchedule(schedule);
+    } else {
+      setSelectedSchedule(null);
+    }
+
     setIsOpen(true);
   };
+
   return (
     <>
-      <EditLeagueScheduleDialog
+      <LeagueScheduleDialog
         onOpenDialog={isOpen}
         onCloseDialog={() => setIsOpen(false)}
         initialValues={selectedSchedule}
+        mode={mode}
       />
+      <ConfirmationDialog />
 
       <TabsContent value="gitGud">
-        <Card className="bg-gradient-to-br from-blue-900 via-gray-800 to-blue-900">
+        <Card className="relative bg-gradient-to-br from-blue-900 via-gray-800 to-blue-900">
           <CardHeader className="relative overflow-hidden text-center">
             <div className="absolute inset-0 bg-gradient-to-r from-blue-500/20 to-red-500/20" />
             <CardTitle className="relative z-10 text-4xl font-bold text-red-500">
@@ -141,75 +111,115 @@ export const LeagueScheduleContent = ({
             </CardDescription>
           </CardHeader>
 
-          <CardContent className="space-y-2">
-            {dummyScheduleList.map((schedule, index) => {
-              const raceDate = new Date(schedule.date);
-              const month = raceDate
-                .toLocaleDateString("en-US", { month: "short" })
-                .toUpperCase();
-              const day = raceDate.getDate();
-              const celsius = Math.floor(((schedule.temp - 32) * 5) / 9);
+          <Button
+            className="absolute top-10 right-6 z-99"
+            onClick={() => onSubmit({ mode: "Create" })}
+          >
+            Add Schedule
+          </Button>
 
-              return (
-                <div key={schedule.id} className="flex items-center gap-4">
+          <CardContent className="space-y-4">
+            {scheduleList.length > 0 ? (
+              scheduleList.map((schedule, index) => {
+                const raceDate = new Date(schedule.date);
+                const month = raceDate
+                  .toLocaleDateString("en-US", { month: "short" })
+                  .toUpperCase();
+                const day = raceDate.getDate();
+                const celsius = Math.floor(((schedule.temp - 32) * 5) / 9);
+
+                return (
                   <div
-                    className={cn(
-                      "flex h-23 w-45 items-center justify-center gap-x-2 font-bold text-white",
-                      index >= Math.floor(dummyScheduleList.length / 2)
-                        ? "bg-red-600"
-                        : "bg-blue-600",
-                    )}
+                    key={schedule.id}
+                    className="flex flex-col items-stretch overflow-hidden rounded-lg shadow-lg md:flex-row md:gap-4"
                   >
-                    <div className="text-xl">{month}</div>
-                    <div className="text-xl">{day}</div>
-                  </div>
-
-                  <div className="flex-1 border-2 border-gray-300 bg-white shadow-lg">
-                    <div className="flex items-center justify-between border-b border-gray-300 px-4 py-3 text-lg font-bold tracking-wide uppercase">
-                      <div className="flex-1 text-center">
-                        {schedule.trackName}
-                      </div>
-                      {isAdmin && (
-                        <div className="flex gap-2">
-                          <Button
-                            variant="outline"
-                            onClick={() => onEdit(schedule)}
-                            className="h-8 w-8"
-                          >
-                            <Edit3 />
-                          </Button>
-
-                          <Button onClick={() => {}} className="h-8 w-8">
-                            <Trash />
-                          </Button>
-                        </div>
+                    <div
+                      className={cn(
+                        "flex w-full items-center justify-center gap-x-2 py-2 font-bold text-white md:w-45 md:py-0",
+                        index >= Math.floor(scheduleList.length / 2)
+                          ? "bg-red-600"
+                          : "bg-blue-600",
                       )}
+                    >
+                      <div className="text-lg md:text-xl">{month}</div>
+                      <div className="text-lg md:text-xl">{day}</div>
                     </div>
 
-                    <div className="flex justify-around px-4 py-2 text-sm font-medium">
-                      <div>{schedule.raceLength} MINUTES</div>
-                      <div>
-                        {schedule.temp}°F / {celsius}°C
+                    <div className={cn("relative flex-1 bg-white shadow-lg")}>
+                      <div className="flex flex-col items-start justify-between gap-2 border-b border-gray-300 px-2 text-sm font-semibold tracking-wide uppercase sm:flex-row md:px-4 md:pt-6 md:text-lg">
+                        <div className={cn("flex-1 py-2 pb-6 text-center")}>
+                          {schedule.trackName}
+                        </div>
+
+                        {isAdmin && (
+                          <div className="absolute top-2 right-2 flex gap-2 sm:self-start">
+                            <Button
+                              variant="outline"
+                              onClick={() =>
+                                onSubmit({ schedule, mode: "Edit" })
+                              }
+                              className="h-6 w-6"
+                            >
+                              <Edit3 />
+                            </Button>
+
+                            <Button
+                              onClick={() => onDelete(schedule.id)}
+                              className="h-6 w-6"
+                            >
+                              <Trash />
+                            </Button>
+                          </div>
+                        )}
                       </div>
 
-                      <div>
-                        {raceDate.toLocaleDateString("en-US", {
-                          month: "numeric",
-                          day: "numeric",
-                          year: "2-digit",
-                        })}{" "}
-                        {raceDate.toLocaleTimeString("en-US", {
-                          hour: "numeric",
-                          minute: "2-digit",
-                          hour12: false,
-                        })}{" "}
-                        iX
+                      <div className="flex flex-col justify-around gap-1 px-2 py-2 font-medium sm:flex-row sm:gap-0 md:px-4 md:text-sm">
+                        <div className="text-xs font-normal lg:text-base">
+                          {schedule.raceLength} MINUTES
+                        </div>
+
+                        <div className="text-xs font-normal lg:text-base">
+                          {schedule.temp}°F / {celsius}°C
+                        </div>
+
+                        <div className="text-xs font-normal lg:text-base">
+                          {raceDate.toLocaleDateString("en-US", {
+                            month: "numeric",
+                            day: "numeric",
+                            year: "2-digit",
+                          })}{" "}
+                          {raceDate.toLocaleTimeString("en-US", {
+                            hour: "numeric",
+                            minute: "2-digit",
+                            hour12: false,
+                          })}{" "}
+                          iX
+                        </div>
                       </div>
                     </div>
                   </div>
+                );
+              })
+            ) : (
+              <div className="flex flex-col items-center justify-center py-16 text-center">
+                <div className="mb-2 text-2xl font-bold text-gray-400">
+                  No Races Scheduled
                 </div>
-              );
-            })}
+
+                <div className="mb-6 text-gray-500">
+                  Season 1 schedule is empty. Start by adding your first race.
+                </div>
+
+                {isAdmin && (
+                  <Button
+                    onClick={() => onSubmit({ mode: "Create" })}
+                    className="bg-blue-600 hover:bg-blue-700"
+                  >
+                    Add First Race
+                  </Button>
+                )}
+              </div>
+            )}
           </CardContent>
         </Card>
       </TabsContent>


### PR DESCRIPTION
  - Consolidate EditLeagueScheduleDialog into unified LeagueScheduleDialog component
  - Add mode prop ("Create" | "Edit") to handle both operations
  - Update form schemas with proper validation and type consistency
  - Fix server procedures to handle seasonNumber field in edit operations
  - Add proper date string to Date conversion in create/edit mutations
  - Improve empty state design with better messaging and admin actions
  - Clean up unused imports and align schema types across procedures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added full create, edit, and delete flow for league schedules, including an “Add Schedule” button, confirmation dialog on delete, and success/error toasts.
  - Unified schedule dialog supports both Create and Edit modes with dynamic titles, labels, and pending states.

- Improvements
  - Forms now enforce clearer field requirements and sensible defaults (e.g., season, temperature, race length).
  - Schedule list renders dynamically from provided data and refreshes after changes.

- Style
  - Increased schedule page container width for better content fit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->